### PR TITLE
Fixes Deprecated Notice - Optional Param

### DIFF
--- a/pmpro-member-badges.php
+++ b/pmpro-member-badges.php
@@ -20,7 +20,7 @@ function pmpromb_load_textdomain() {
 }
 add_action( 'plugins_loaded', 'pmpromb_load_textdomain' );
 
-function pmpromb_show_badge( $user_id = NULL, $echo = true, $args ) {
+function pmpromb_show_badge( $user_id = NULL, $echo = true, $args = array() ) {
 	if ( empty( $user_id ) ) {
 		global $current_user;
 		$user_id = $current_user->ID;
@@ -29,11 +29,6 @@ function pmpromb_show_badge( $user_id = NULL, $echo = true, $args ) {
 	// If no user ID is set, return false.
 	if ( empty( $user_id ) ) {
 		return false;
-	}
-
-	// If no args are set, set up an empty array.
-	if ( empty( $args ) ) {
-		$args = array();
 	}
 
 	// Set default size if not set in args.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-badges/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-badges/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Assigns the last parameter a default value as not having this throws errors in PHP 8+

### How to test the changes in this Pull Request:

1. Activate Member Badges with debugging enabled
2. No errors for this should be shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

